### PR TITLE
Add simple selector for switching between 2 and 4 space tabs

### DIFF
--- a/keymaps/status-tab-spacing.cson
+++ b/keymaps/status-tab-spacing.cson
@@ -9,3 +9,4 @@
 # https://atom.io/docs/latest/advanced/keymaps
 '.workspace':
   'ctrl-alt-o': 'status-tab-spacing:toggle'
+  'ctrl-alt-p': 'editor:set-tab-spacing'

--- a/lib/status-tab-spacing-view.coffee
+++ b/lib/status-tab-spacing-view.coffee
@@ -1,4 +1,5 @@
 {View} = require 'atom'
+TabSpacingSelector = require './tab-spacing-selector'
 
 module.exports =
 class StatusTabSpacingView extends View
@@ -7,6 +8,7 @@ class StatusTabSpacingView extends View
 
   initialize: ->
     atom.workspaceView.command "status-tab-spacing:toggle", => @toggle()
+    atom.workspaceView.command "editor:set-tab-spacing", => @setTabSpacing()
 
   destroy: ->
     @detach()
@@ -23,6 +25,9 @@ class StatusTabSpacingView extends View
 
     @getTabSpacing()
 
-  getTabSpacing: =>
+  getTabSpacing: ->
     spaces = atom.config.get('editor.tabLength')
-    @text("Spaces: #{spaces}").show()
+    @text("Spaces: #{spaces}").show().on 'click', @setTabSpacing
+
+  setTabSpacing: ->
+    new TabSpacingSelector()

--- a/lib/tab-spacing-selector.coffee
+++ b/lib/tab-spacing-selector.coffee
@@ -1,0 +1,26 @@
+{$$, SelectListView} = require 'atom'
+
+module.exports =
+class TabSpacingSelector extends SelectListView
+  initialize: ->
+    super
+    @addClass 'overlay from-top'
+    @list.addClass 'mark-active'
+
+    @currentSpacing = atom.config.get 'editor.tabLength'
+    @subscribe atom.config.observe 'editor.tabLength', => @currentSpacing = atom.config.get 'editor.tabLength'
+
+    @setItems ['2 spaces', '4 spaces']
+    atom.workspaceView.append this
+    @focusFilterEditor()
+
+  viewForItem: (item) ->
+    element = document.createElement 'li'
+    element.classList.add 'active' if parseInt(item) is @currentSpacing
+    element.textContent = item
+    element
+
+  confirmed: (item) ->
+    @cancel()
+    return unless item
+    atom.config.set 'editor.tabLength', parseInt item


### PR DESCRIPTION
Nothing too fancy, but what do you think of this approach? I'd like to get some feedback, then later add in autodetection and per-tab spacing.

![screen shot 2014-02-28 at 6 24 09 pm](https://f.cloud.github.com/assets/106826/2300287/b0561d18-a0e8-11e3-8ff7-cfca38067eb7.png)

Also - no tests yet and the selector is set to show on `ctrl-alt-p` but that's just a random key I chose. Feel free to change it.
