### PR TITLE
Replace deprecated selector

### DIFF
--- a/keymaps/status-tab-spacing.cson
+++ b/keymaps/status-tab-spacing.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-o': 'status-tab-spacing:toggle'
   'ctrl-alt-p': 'editor:set-tab-spacing'


### PR DESCRIPTION
Atom Deprecation Cop says:

> Use the `atom-workspace` tag instead of the `workspace` class.
